### PR TITLE
Fix Decimal typecasting bug

### DIFF
--- a/test/dummy/app/models/my_model.rb
+++ b/test/dummy/app/models/my_model.rb
@@ -12,5 +12,7 @@ class MyModel < ApplicationRecord
     attribute :listy_integer, :integer, array: true
 
     attribute :enumy, :enum, of: [nil, "placed", "confirmed"]
+
+    attribute :decimy, :decimal
   end
 end

--- a/test/serialize_attributes/store_test.rb
+++ b/test/serialize_attributes/store_test.rb
@@ -9,7 +9,7 @@ module SerializeAttributes
     end
 
     test ".attribute_names with array: true/false" do
-      assert_equal %i[booly booly_default stringy timestamp listy listy_default listy_integer enumy],
+      assert_equal %i[booly booly_default stringy timestamp listy listy_default listy_integer enumy decimy],
                    @store.attribute_names
 
       assert_equal %i[listy listy_default listy_integer],

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -60,13 +60,32 @@ class SerializeAttributesTest < ActiveSupport::TestCase
         attribute :height, :decimal
       end
     end
-    record = klass.new(height: BigDecimal("0.42"))
 
+    record = klass.new(height: BigDecimal("0.42"))
     assert_equal BigDecimal("0.42"), record.height
 
     record.save!
-    record.reload
+    assert_equal BigDecimal("0.42"), record.height
 
+    record.reload
+    assert_equal BigDecimal("0.42"), record.height
+
+    record.update(height: BigDecimal("0.21"))
+    assert_equal BigDecimal("0.21"), record.height
+  end
+
+  test "Assigning other attributes doesn't interfer with bigdecimal typecasting" do
+    klass = Class.new(MyModel) do
+      serialize_attributes :data do
+        attribute :stringy, :string
+        attribute :height,  :decimal
+      end
+    end
+
+    record = klass.new(height: 0.42)
+    assert_equal BigDecimal("0.42"), record.height
+
+    record.assign_attributes stringy: "Chunky Bacon!"
     assert_equal BigDecimal("0.42"), record.height
   end
 
@@ -136,14 +155,15 @@ class SerializeAttributesTest < ActiveSupport::TestCase
         listy: [],
         listy_default: ["first"],
         listy_integer: [],
-        enumy: nil
+        enumy: nil,
+        decimy: nil
       },
       record.serialized_attributes_on(:data)
     )
   end
 
   test ".serialized_attribute_names" do
-    assert_equal %i[booly booly_default stringy timestamp listy listy_default listy_integer enumy],
+    assert_equal %i[booly booly_default stringy timestamp listy listy_default listy_integer enumy decimy],
                  MyModel.serialized_attribute_names(:data)
 
     assert_equal %i[booly booly_default], MyModel.serialized_attribute_names(:data, :boolean)


### PR DESCRIPTION
Decimal typecasting failed after assignment, even of non-decimal attribute. Typecasting is correct after saving or when reading from the DB.

This recast any decimal in a store that has been assigned but not saved when reading the decimal attribute.

The diff is big, but the change to the logic is not. We get rid of the `@_bad_assignement` (🎉) and only recast under specific condition. The rest is refactoring to stay under the 15 lines method threshold.