### PR TITLE
Refactor internals with AttributeSet to fix typecasting woes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
+This version moves some of the internals around. Now the store columns are modelled as an
+`ActiveModel::AttributeSet`, rather than a simple hash. This allows the library to do
+proper dirty tracking & casting, similar to how Rails itself works with regular attributes.
+
+As a result of this change, unfortunately two (unused) features had to be removed:
+
+* **BREAKING** Default values using a block are no longer supported
+* **BREAKING** `Store#default` no longer accepts a second `context` argument
+* **BREAKING** Arrays no longer support default values (default is always `[]`)
+
+However, the following features have been added:
+
+* Typecasting is now transparent to the user so complex types can be immediately read back
+  after setting
+
 ## [0.6.0]
 
 * Add predicated methods to attributes.
@@ -40,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Initial release
 
-[Unreleased]: https://github.com/zaikio/serialize_attributes/compare/v0.6.0..HEAD
+[Unreleased]: https://github.com/zaikio/serialize_attributes/compare/v1.0.0..HEAD
+[1.0.0]: https://github.com/zaikio/serialize_attributes/compare/v0.6.0..v1.0.0
 [0.6.0]: https://github.com/zaikio/serialize_attributes/compare/v0.5.0..v0.6.0
 [0.5.0]: https://github.com/zaikio/serialize_attributes/compare/v0.4.1..v0.5.0
 [0.4.1]: https://github.com/zaikio/serialize_attributes/compare/v0.4.0..v0.4.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serialize_attributes (0.6.0)
+    serialize_attributes (1.0.0)
       activemodel (>= 6)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -148,12 +148,7 @@ class MyModel
 end
 ```
 
-Please note that the default value for an array attribute is always `[]`, unless you
-specify a `default` attribute yourself explicitly:
-
-```ruby
-attribute :emails, :string, array: true, default: ["unknown@example.com"]
-```
+Please note that the default value for an array attribute is always `[]`.
 
 ### Enumerated ("enum") types
 

--- a/lib/serialize_attributes/store.rb
+++ b/lib/serialize_attributes/store.rb
@@ -4,17 +4,18 @@ module SerializeAttributes
   # SerializeAttributes::Store is the individual store, keyed by name. You can get a
   # reference to the store by calling `Model.serialized_attributes_store(column_name)`.
   class Store
-    def initialize(model_class, column_name, &block)
-      # :nodoc:
+    def initialize(model_class, column_name, &block) # :nodoc:
       @model_class = model_class
       @column_name = column_name
-      @attributes = {}
+      @attribute_types = {}
       @defaults = {}
 
       instance_exec(&block)
       wrap_store_column
-      [self, @attributes, @defaults].each(&:freeze)
+      [self, @attribute_types, @defaults].each(&:freeze)
     end
+
+    attr_reader :attribute_types
 
     # Get a list of the attributes managed by this store. Pass an optional `type` argument
     # to filter attributes by their type.
@@ -33,13 +34,13 @@ module SerializeAttributes
     #
     #
     def attribute_names(type: nil, array: nil)
-      attributes = @attributes
-      attributes = @attributes.select { |_, v| v.is_a?(ArrayWrapper) == array } unless array.nil?
+      attributes = @attribute_types
+      attributes = @attribute_types.select { |_, v| v.is_a?(ArrayWrapper) == array } unless array.nil?
       if type
         attributes_for_type(attributes, type)
       else
         attributes
-      end.keys
+      end.keys.map(&:to_sym)
     end
 
     # Get a list of enumerated options for the column `name` in this store.
@@ -47,46 +48,44 @@ module SerializeAttributes
     #   Model.serialized_attributes_store(:settings).enum_options(:enumy)
     #   => [nil, "placed", "confirmed"]
     def enum_options(name)
-      type = @attributes.fetch(name.to_sym)
+      type = @attribute_types.fetch(name.to_s)
       raise ArgumentError, "`#{name}` attribute is not an enum type" unless type.respond_to?(:options)
 
       type.options
     end
 
-    # Cast a stored attribute against a given name
+    # Cast a stored attribute against a given name into an
+    # ActiveModel::Attribute::FromUser object (the cast value can be got using `#value`).
     #
-    #    Model.serialized_attributes_store(:settings).cast(:user_name, 42)
+    #    Model.serialized_attributes_store(:settings).cast(:user_name, 42).value
     #    => "42"
     def cast(name, value)
-      # @attributes.fetch(name.to_sym) returns the Type as defined in ActiveModel::Type or
-      # raise an error if the type is unknown.
-      # Type::Integer.new.cast("42") => 42
-      @attributes.fetch(name.to_sym).cast(value)
+      type = @attributes_types.fetch(name.to_s)
+
+      ActiveModel::Attribute.from_user(name, value, type)
     end
 
-    # Deserialize a stored attribute using the value from the database (or elsewhere)
+    # Deserialize a stored attribute using the value from the database (or elsewhere) into
+    # an ActiveModel::Attribute::FromDatabase object (the cast value can be got using
+    # `#value`).
     #
-    #   Model.serialized_attributes_store(:settings).deserialize(:subscribed, "0")
+    #   Model.serialized_attributes_store(:settings).deserialize(:subscribed, "0").value
     #   => false
     def deserialize(name, value)
-      attribute = @attributes[name.to_sym]
-      if attribute.nil?
+      type = @attribute_types[name.to_s]
+      if type.nil?
         raise "The attribute #{name} is not defined in serialize_attribute method in the #{@model_class} class."
       end
 
-      attribute.deserialize(value)
+      ActiveModel::Attribute.from_database(name, value, type)
     end
 
-    # Retrieve the default value for a given block. If the default is a Proc, it can be
-    # optionally executed in the context of the model.
+    # Retrieve the default value for a given block.
     #
     #   Model.serialized_attributes_store(:settings).default(:subscribed)
     #   #=> false
-    def default(name, context = nil)
-      given = @defaults[name]
-      return (context || self).instance_exec(&given) if given.is_a?(Proc)
-
-      given
+    def default(name)
+      @defaults[name.to_s]
     end
 
     private
@@ -102,7 +101,7 @@ module SerializeAttributes
     NO_DEFAULT = Object.new
 
     def attribute(name, type, default: NO_DEFAULT, array: false, **type_options)
-      name = name.to_sym
+      name = name.to_s
       type = ActiveModel::Type.lookup(type, **type_options) if type.is_a?(Symbol)
 
       if array
@@ -111,7 +110,7 @@ module SerializeAttributes
         type = ArrayWrapper.new(type)
       end
 
-      @attributes[name] = type
+      @attribute_types[name] = type
 
       if default != NO_DEFAULT
         @defaults[name] = default
@@ -122,68 +121,44 @@ module SerializeAttributes
       type.attach_validations_to(@model_class, name) if type.respond_to?(:attach_validations_to)
 
       @model_class.module_eval <<~RUBY, __FILE__, __LINE__ + 1
-        def #{name}                                          # def user_name
-          if @_bad_typcasting                                #   if @_bad_typcasting
-            store =                                          #     store =
-              read_attribute_before_type_cast(               #       read_attribute_before_type_cast(
-                :#{@column_name}                             #         :settings
-              )                                              #       )
-            @_bad_typcasting = false                         #     @_bad_typcasting = false
-          else                                               #   else
-            store = public_send(:#{@column_name})            #     store = public_send(:settings)
-          end                                                #   end
-                                                             #
-          if store.key?("#{name}")                           #   if store.key?("user_name")
-            store["#{name}"]                                 #     store["user_name"]
-          else                                               #   else
-            self.class                                       #     self.class
-              .serialized_attributes_store(:#{@column_name}) #       .serialized_attributes_store(:settings)
-              .default(:#{name}, self)                       #       .default(:user_name, self)
-          end                                                #   end
-        end                                                  # end
-                                                             #
-        unless #{array}                                      # unless array
-          def #{name}?                                       #   def user_name?
-            query_attribute("#{name}")                       #     query_attribute(:user_name)
-          end                                                #   end
-        end                                                  # end
-                                                             #
-        def #{name}=(value)                                  # def user_name=(value)
-          cast_value = self.class                            #   cast_value = self.class
-            .serialized_attributes_store(:#{@column_name})   #     .serialized_attributes_store(:settings)
-            .cast(:#{name}, value)                           #     .cast(:user_name, value)
-          store = public_send(:#{@column_name})              #   store = public_send(:settings)
-                                                             #
-          if #{array} && cast_value == ArrayWrapper::EMPTY   #   if array && cast_value == ArrayWrapper::EMPTY
-            store.delete("#{name}")                          #     store.delete("user_name")
-          else                                               #   else
-            store.merge!("#{name}" => cast_value)            #     store.merge!("user_name" => cast_value)
-          end                                                #   end
-          public_send(:#{@column_name}=, store)              #   public_send(:settings=, store)
-                                                             #
-          values_before_typecast = store.values              #   values_before_typecast = store.values
-          values_after_typecast =                            #   values_after_typecast =
-            public_send(:#{@column_name}).values             #     public_send(:settings).values
-          @_bad_typcasting =                                 #     @_bad_typcasting =
-            values_before_typecast != values_after_typecast  #       values_before_typecast != values_after_typecast
-        end                                                  # end
+        def #{name}                               # def user_name
+          store = public_send(:#{@column_name})   #   store = public_send(:settings)
+          store.fetch_value("#{name}")            #   store.fetch_value("user_name")
+        end                                       # end
+
+        unless #{array}                           # unless false
+          def #{name}?                            #   def user_name?
+            query_attribute("#{name}")            #     query_attribute("user_name")
+          end                                     #   end
+        end                                       # end
+
+        def #{name}=(value)                       # def user_name=(value)
+          store = public_send(:#{@column_name})   #   store = public_send(:settings)
+          try(:#{@column_name}_will_change!)      #   try(:settings_will_change!)
+          store.write_from_user("#{name}", value) #   store.write_from_user("user_name", value)
+        end                                       # end
       RUBY
     end
 
     class ArrayWrapper < SimpleDelegator # :nodoc:
-      EMPTY = Object.new
-
       def cast(value)
-        # We don't want to store the null value, because array types _always_ have a default
-        # configured. So we return this special object here, and check it again before
-        # updating the underlying store.
-        return EMPTY unless value
+        return [] if value.nil?
 
         Array(value)
       end
 
       def deserialize(value)
-        value.map { __getobj__.deserialize(_1) }
+        Array.wrap(value).map { __getobj__.deserialize(_1) }
+      end
+    end
+
+    class AttributeSet < ::ActiveModel::AttributeSet # :nodoc:
+      def ==(other)
+        attributes == if other.is_a?(Hash)
+                        other
+                      else
+                        other.attributes
+                      end
       end
     end
 
@@ -193,29 +168,54 @@ module SerializeAttributes
         @store = store
       end
 
+      def cast(value)
+        case value
+        when Hash then deserialize(value.stringify_keys)
+        else value
+        end
+      end
+
+      def changed_in_place?(raw_original_value, new_value)
+        AttributeSet.new(raw_original_value) != new_value
+      end
+
+      def serialize(value)
+        super(value.values_for_database)
+      end
+
       def deserialize(...)
-        result = __getobj__.deserialize(...)
+        result = super
         return result unless @store && result.respond_to?(:each)
 
-        result.each_with_object({}) do |(attribute_name, serialized_value), out|
-          out[attribute_name] = @store.deserialize(attribute_name, serialized_value)
-        end
+        AttributeSet.new(
+          @store.attribute_types.each_with_object({}) do |(attribute, type), out|
+            out[attribute] = if result.key?(attribute)
+                               @store.deserialize(attribute, result[attribute])
+                             else
+                               ActiveModel::Attribute.from_user(attribute, @store.default(attribute), type)
+                             end
+          end
+        )
       end
     end
 
-    # This method wraps the original store column and catches the `deserialize` call -
+    # This method wraps the original store column and catches several read/write calls;
     # this gives us a chance to convert the data in the database back into our types.
     #
-    # We're using the block form of `.attribute` to avoid loading the database schema just
-    # to figure out our wrapping type.
+    # We using the block form of `.attribute` when the schema is lazily loaded (and has
+    # not been loaded yet).
     def wrap_store_column
-      return unless @model_class.respond_to?(:attribute_types)
+      if respond_to?(:schema_loaded?) && !schema_loaded?
+        store = self
+        @model_class.attribute(@column_name) do
+          original_type = @model_class.attribute_types.fetch(@column_name.to_s)
+          StoreColumnWrapper.new(original_type, store)
+        end
 
-      store = self
-
-      @model_class.attribute(@column_name) do
+      else
         original_type = @model_class.attribute_types.fetch(@column_name.to_s)
-        StoreColumnWrapper.new(original_type, store)
+        type = StoreColumnWrapper.new(original_type, self)
+        @model_class.attribute(@column_name, type)
       end
     end
   end

--- a/lib/serialize_attributes/version.rb
+++ b/lib/serialize_attributes/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SerializeAttributes
-  VERSION = "0.6.0"
+  VERSION = "1.0.0"
 end

--- a/test/dummy/app/models/my_model.rb
+++ b/test/dummy/app/models/my_model.rb
@@ -7,10 +7,11 @@ class MyModel < ApplicationRecord
     attribute :timestamp, :datetime
 
     attribute :listy, :string, array: true
-    attribute :listy_default, :string, array: true, default: ["first"]
 
     attribute :listy_integer, :integer, array: true
 
     attribute :enumy, :enum, of: [nil, "placed", "confirmed"]
+
+    attribute :decy, :decimal
   end
 end

--- a/test/serialize_attributes/store_test.rb
+++ b/test/serialize_attributes/store_test.rb
@@ -9,15 +9,15 @@ module SerializeAttributes
     end
 
     test ".attribute_names with array: true/false" do
-      assert_equal %i[booly booly_default stringy timestamp listy listy_default listy_integer enumy],
+      assert_equal %i[booly booly_default stringy timestamp listy listy_integer enumy decy],
                    @store.attribute_names
 
-      assert_equal %i[listy listy_default listy_integer],
+      assert_equal %i[listy listy_integer],
                    @store.attribute_names(array: true)
     end
 
     test ".attribute_names with type and array: true/false" do
-      assert_equal %i[listy listy_default],
+      assert_equal %i[listy],
                    @store.attribute_names(type: :string, array: true)
       assert_equal %i[stringy], @store.attribute_names(type: :string, array: false)
     end


### PR DESCRIPTION
This PR is a sizeable refactor of this gem to reuse some of the core features from [`ActiveModel::AttributeSet`](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/attribute_set.rb). The key change is to track changes as `Attribute` objects, rather than their underlying values. This allows us (and Rails) to determine whether a change has come from the user, or the database, and thus what typecasting to apply at that point.

The complexity in the gem has shifted now from the getter/setter methods for each attribute, onto the `StoreColumnWrapper` class which translates the actual column in Rails into a new `AttributeSet` object. As properties are mutated, the `AttributeSet` tracks the changes, and when the object is serialized for the database it takes care of all the ugly serialization parts.

Unfortunately, we had to lose two (as far as I can tell unused) features, blocks with default values and arrays with default values that wasn't an empty array.

We had to lose the block support because the default value is now calculated by the `StoreColumnWrapper#deserialize` method, and at that point in the code it does not have access to the underlying record object (this is a Rails design presumably to enforce modularity). Default values cannot be calculated without that context.

Array defaults meanwhile turned out to be rather difficult to retain when `AttributeSet` is handling change tracking for us. The sentinel `EMPTY` value required a lot of modification of pretty much every method to accommodate; it didn't seem worth the carrying cost.

However, despite these two feature losses, the big major win is that you can now read back a value immediately after writing it (before persisting it to the DB). This replaces all of the "bad_typecasting" logic that we had before.

Closes https://github.com/zaikio/serialize_attributes/issues/58