### PR TITLE
Fix dirty tracking after loading clean record

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,7 @@ Metrics/ClassLength:
   Exclude:
     - lib/serialize_attributes/store.rb
     - test/**/*_test.rb
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - bin/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1]
+
+* Fix dirty tracking after loading records without mutating them
+
 ## [1.0.0]
 
 This version moves some of the internals around. Now the store columns are modelled as an

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    serialize_attributes (1.0.0)
+    serialize_attributes (1.0.1)
       activemodel (>= 6)
 
 GEM

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../test", __dir__)
+
+require "bundler/setup"
+require "rails/plugin/test"

--- a/lib/serialize_attributes/version.rb
+++ b/lib/serialize_attributes/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SerializeAttributes
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -167,4 +167,25 @@ class SerializeAttributesTest < ActiveSupport::TestCase
 
     assert_equal "Enum-arrays not currently supported", ex.message
   end
+
+  test "change tracking: no changes after loading record and reading attributes" do
+    record = MyModel.create!(normal_column: "yes", booly: false, stringy: "hello")
+
+    assert_not record.booly? # triggers actually reading the column value...
+    assert_not record.changed?, "Expected no changes, found: #{record.changes.as_json}"
+
+    record = MyModel.find(record.id)
+    assert_not record.changed?, "Expected no changes, found: #{record.changes.as_json}"
+
+    record.booly = true
+    assert record.changed?
+  end
+
+  test "change tracking: new records" do
+    record = MyModel.new
+    assert_not record.changed?
+
+    record.booly = true
+    assert record.changed?
+  end
 end


### PR DESCRIPTION
To trigger this bug, we need to load the properties set and try and read one of the values back. This triggers the query on `ActiveModel::Attribute#has_been_read?`, and the logic for checking whether the object has been mutated becomes [more involved](https://github.com/rails/rails/blob/1ab9de5594e26a91c896cdb01af5faa9634f2591/activemodel/lib/active_model/attribute.rb#L68).

To fix it, we need to:

  * Actually deserialize raw_original_value (it's a JSON string usually)
  * Check both attribute sets more carefully
  * Check if any of the types have been changed "in place", which is true if you modify the record without a usual assignment, especially on arrays, e.g:
    ```ruby
    record.listy << "foo"
    ```