### PR TITLE
Include possible enum values in enum validation error message

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,5 @@
+---
+de:
+  errors:
+    messages:
+      inclusion_with_options: "%{value} ist nicht einer von %{options}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,5 @@
+---
+en:
+  errors:
+    messages:
+      inclusion_with_options: "%{value} is not one of %{options}"

--- a/lib/serialize_attributes.rb
+++ b/lib/serialize_attributes.rb
@@ -3,6 +3,8 @@
 require "serialize_attributes/version"
 require "serialize_attributes/store"
 require "serialize_attributes/types/enum"
+require "serialize_attributes/validators/inclusion_with_options_validator"
+require "serialize_attributes/railtie" if defined?(Rails::Railtie)
 
 # Serialize ActiveModel attributes in JSON using type casting
 module SerializeAttributes

--- a/lib/serialize_attributes/railtie.rb
+++ b/lib/serialize_attributes/railtie.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SerializeAttributes
+  class Railtie < Rails::Railtie # :nodoc:
+    initializer "serialize_attributes.translations" do |_app|
+      locale_files = Dir[File.expand_path("../../config/locales/*.yml", __dir__)]
+      raise "Could not find locale files" unless locale_files.any?
+
+      I18n.load_path += locale_files
+    end
+  end
+end

--- a/lib/serialize_attributes/types/enum.rb
+++ b/lib/serialize_attributes/types/enum.rb
@@ -30,7 +30,11 @@ module SerializeAttributes
       end
 
       def attach_validations_to(object, field_name)
-        object.validates_inclusion_of(field_name, in: @options)
+        object.validates_with(
+          Validators::InclusionWithOptionsValidator,
+          attributes: [field_name],
+          in: @options
+        )
       end
 
       delegate_missing_to :@type

--- a/lib/serialize_attributes/validators/inclusion_with_options_validator.rb
+++ b/lib/serialize_attributes/validators/inclusion_with_options_validator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module SerializeAttributes
+  module Validators
+    # This validator behaves exactly like a normal inclusion validator, except that it
+    # passes the possible values to the error message, e.g:
+    #
+    #   class MyModel
+    #      validates :foo, inclusion: { in: %w(a b c) }
+    #
+    #   record = MyModel.new
+    #   record.validate
+    #   record.errors.full_messages
+    #   #=> ["Foo is not one of a, b, c"]
+    class InclusionWithOptionsValidator < ::ActiveModel::Validations::InclusionValidator
+      def validate_each(record, attribute, value)
+        return if include?(record, value)
+
+        humanised_options = options.fetch(:in).map { |option| option || "(null)" }.join(", ")
+
+        record.errors.add(
+          attribute,
+          :inclusion_with_options,
+          value: value,
+          options: humanised_options
+        )
+      end
+    end
+  end
+end

--- a/test/serialized_attributes_test.rb
+++ b/test/serialized_attributes_test.rb
@@ -76,6 +76,8 @@ class SerializeAttributesTest < ActiveSupport::TestCase
 
     record.enumy = "unknown"
     assert_not record.valid?
+    assert_includes record.errors.full_messages,
+                    "Enumy unknown is not one of (null), placed, confirmed"
 
     record.enumy = "confirmed"
     assert record.valid?


### PR DESCRIPTION
Rails does not reveal what the possible values are for an enum by default. It's actually impossible to get them out just by customising the translation string, because they are hidden from I18n altogether using `options.except(:in, :within)`:

```ruby
      def validate_each(record, attribute, value)
        unless include?(record, value)
          record.errors.add(attribute, :inclusion, **options.except(:in, :within).merge!(value: value))
        end
      end
```

This restriction isn't explained in the source code, so I can see two possible reasons for this:

  1. Security through obscurity: don't reveal possible values and it reduces an attack vector where somebody abuses a column with a magic value (e.g. `role = superadmin`)

  2. The `in:` option supports `Range`, which means you could potentially have something like `in: (1..100_000)`. Printing that as a list of possible options would be a bad choice...

However, the enums we're working with in this gem are usually a much smaller set, and could really provide a better user experience. So this commit adds a validator which extends the normal inclusion validator, but also injects the possible values in the message.

Turns out the hardest part was injecting the translations. With a Rails::Engine-style gem, this gets handled automatically, but here I had to use a Railtie just to get Rails to recognise them (this is important, if you just do `I18n.load_path << ...` when Rails loads itself it _overwrites_ whatever translation files you set 🙈